### PR TITLE
pyproject.toml: requires-python = ">=3.9"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,11 @@ authors = [
 ]
 description = "NNTP Library (including compressed headers)"
 readme = "README.md"
-requires-python = ">=2.7.9, !=3.0.*, !=3.1.*"
+requires-python = ">=3.9"
 dependencies = [
     "python-dateutil",
 ]
 classifiers = [
-    "Programming Language :: Python :: 2",
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Python 3.8 will become EOL in a few weeks.
* https://devguide.python.org/versions