### PR TITLE
with nntp.NNTPClient("localhost") as nntp_client:

### DIFF
--- a/nntp/nntp.py
+++ b/nntp/nntp.py
@@ -539,6 +539,18 @@ class NNTPClient(BaseNNTPClient):
         )
         if reader:
             self.mode_reader()
+    
+    def __enter__(self):
+        """Support for the 'with' context manager statement."""
+        return self
+
+    def __exit__(self, *args):
+        """Support for the 'with' context manager statement."""
+        try:
+            self.quit()
+        except NNTPError:
+            self.close()
+            raise
 
     # session administration commands
     def capabilities(self, keyword=None):

--- a/tests/test_inn2.py
+++ b/tests/test_inn2.py
@@ -23,10 +23,41 @@ def test_nntp_client():
     assert newsgroups == DEFAULT_NEWGROUPS
 
 
+def test_context_manager():
+    """
+    https://docs.python.org/3/reference/datamodel.html#context-managers
+    """
+    with nntp.NNTPClient("localhost") as nntp_client:
+        newsgroups = set(nntp_client.list_newsgroups())
+        assert newsgroups == DEFAULT_NEWGROUPS
+
+
+@pytest.mark.xfail(reason="[Errno 9] Bad file descriptor", raises=OSError, strict=True)
+def test_context_manager_on_close():
+    """
+    nntp_client.close() should normally not be called within the context manager.
+    """
+    with nntp.NNTPClient("localhost") as nntp_client:
+        newsgroups = set(nntp_client.list_newsgroups())
+        assert newsgroups == DEFAULT_NEWGROUPS
+        nntp_client.close()
+
+
+@pytest.mark.xfail(reason="[Errno 9] Bad file descriptor", raises=OSError, strict=True)
+def test_context_manager_on_quit():
+    """
+    nntp_client.quit() should normally not be called within the context manager.
+    """
+    with nntp.NNTPClient("localhost") as nntp_client:
+        newsgroups = set(nntp_client.list_newsgroups())
+        assert newsgroups == DEFAULT_NEWGROUPS
+        nntp_client.quit()
+
+
 def test_nntp_client_without_ssl():
-    nntp_client = nntp.NNTPClient("localhost", use_ssl=False)
-    newsgroups = set(nntp_client.list_newsgroups())
-    assert newsgroups == DEFAULT_NEWGROUPS
+    with nntp.NNTPClient("localhost", use_ssl=False) as nntp_client:
+        newsgroups = set(nntp_client.list_newsgroups())
+        assert newsgroups == DEFAULT_NEWGROUPS
 
 
 @pytest.mark.xfail(
@@ -35,9 +66,9 @@ def test_nntp_client_without_ssl():
     strict=True,
 )
 def test_nntp_client_with_ssl():
-    nntp_client = nntp.NNTPClient("localhost", use_ssl=True)
-    newsgroups = set(nntp_client.list_newsgroups())
-    assert newsgroups == DEFAULT_NEWGROUPS
+    with nntp.NNTPClient("localhost", use_ssl=True) as nntp_client:
+        newsgroups = set(nntp_client.list_newsgroups())
+        assert newsgroups == DEFAULT_NEWGROUPS
 
 
 @pytest.mark.parametrize(
@@ -52,27 +83,29 @@ def test_nntp_client_with_ssl():
     ],
 )
 def test_post(newsgroup):
-    nntp_client = nntp.NNTPClient("localhost")
     headers = {
         "Subject": f"Test post to {newsgroup}",
         "From": "GitHub Actions <actions@github.com>",
         "Newsgroups": newsgroup,
     }
-    assert (
-        nntp_client.post(headers=headers, body=f"This is a test post to {newsgroup}")
-        is True
-    )
+    with nntp.NNTPClient("localhost") as nntp_client:
+        assert (
+            nntp_client.post(
+                headers=headers, body=f"This is a test post to {newsgroup}"
+            )
+            is True
+        )
 
 
 @pytest.mark.parametrize("newsgroup", ["local.general", "local.test", "junk"])
 def test_list_active(newsgroup):
-    nntp_client = nntp.NNTPClient("localhost")
-    articles = nntp_client.list_active(newsgroup)
-    for name, low, high, status in articles:
-        assert name == newsgroup
-        assert low == 0 if newsgroup == "junk" else 1
-        assert high == 1
-        assert status == "n" if newsgroup == "junk" else "y"
+    with nntp.NNTPClient("localhost") as nntp_client:
+        articles = nntp_client.list_active(newsgroup)
+        for name, low, high, status in articles:
+            assert name == newsgroup
+            assert low == 0 if newsgroup == "junk" else 1
+            assert high == 1
+            assert status == "n" if newsgroup == "junk" else "y"
 
 
 @pytest.mark.parametrize(
@@ -87,14 +120,14 @@ def test_list_active(newsgroup):
     ],
 )
 def test_article(newsgroup):
-    nntp_client = nntp.NNTPClient("localhost")
-    total, first, last, group = nntp_client.group(newsgroup)
-    assert total == 0 if newsgroup == "junk" else 1
-    assert first == 1
-    assert last == 0 if newsgroup == "junk" else 1
-    assert group == newsgroup
-    article_number, headers, body = nntp_client.article()
-    assert article_number == 1
-    assert headers["Newsgroups"] == newsgroup
-    assert headers["Subject"] == f"Test post to {newsgroup}"
-    assert body == f"This is a test post to {newsgroup}\r\n".encode("utf-8")
+    with nntp.NNTPClient("localhost") as nntp_client:
+        total, first, last, group = nntp_client.group(newsgroup)
+        assert total == 0 if newsgroup == "junk" else 1
+        assert first == 1
+        assert last == 0 if newsgroup == "junk" else 1
+        assert group == newsgroup
+        article_number, headers, body = nntp_client.article()
+        assert article_number == 1
+        assert headers["Newsgroups"] == newsgroup
+        assert headers["Subject"] == f"Test post to {newsgroup}"
+        assert body == f"This is a test post to {newsgroup}\r\n".encode("utf-8")


### PR DESCRIPTION
Fixes:
```python
with nntp.NNTPClient("localhost") as nntp_client:
```
> TypeError: 'NNTPClient' object does not support the context manager protocol

---

Calling `nntp_client = nntp.NNTPClient("localhost")` but forgetting to subsequently call `nntp_client.quit()` causes two problems:
1. We do not alert the NNTP server that we are done so it unnecessarily leaves resources open.
2. We do not close an open socket on localhost.

The `with nntp.NNTPClient("localhost") as nntp_client:` context manager syntax solves both problems.
* https://docs.python.org/3/reference/datamodel.html#context-managers