### PR TITLE
Lint is redundant with pre-commit.ci

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,19 +11,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  lint:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - run: pipx install poetry
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - name: Install ruff
-        run: poetry install --no-root
-      - name: Run ruff
-        run: poetry run ruff check
-
   mypy:
     strategy:
       fail-fast: false


### PR DESCRIPTION
Ruff is a pre-commit requirement, not needed in Poetry.