### PR TITLE
Add unittests for utils

### DIFF
--- a/nntp/utils.py
+++ b/nntp/utils.py
@@ -186,7 +186,7 @@ def unparse_headers(hdrs: Mapping[str, str]) -> str:
     return "".join([_unparse_header(n, v) for n, v in hdrs.items()]) + "\r\n"
 
 
-def parse_date(value: str) -> datetime:
+def parse_date(value: Union[str, int]) -> datetime:
     """Parse a date as returned by the `DATE` command.
 
     Args:
@@ -207,7 +207,7 @@ def parse_date(value: str) -> datetime:
     return datetime(Y % 10000, m, d, H, M, S, tzinfo=timezone.utc)
 
 
-def parse_epoch(value: str) -> datetime:
+def parse_epoch(value: Union[str, int]) -> datetime:
     """Parse a date as returned by the `DATE` command.
 
     Args:

--- a/nntp/utils.py
+++ b/nntp/utils.py
@@ -120,10 +120,12 @@ def _parse_header(line: str) -> Union[str, tuple[str, str], None]:
     Raises:
         ValueError: If the line cannot be parsed as a header.
     """
+    # End of headers
     if not line or line == "\r\n":
         return None
+    # Continuation line
     if line[0] in " \t":
-        return line[1:].rstrip()
+        return line.rstrip()
     name, value = line.split(":", 1)
     return name.strip(), value.strip()
 
@@ -199,7 +201,7 @@ def parse_date(value: str) -> datetime:
     i = int(value)
     M, S = divmod(i, 100)
     H, M = divmod(M, 100)
-    d, H = divmod(M, 100)
+    d, H = divmod(H, 100)
     m, d = divmod(d, 100)
     Y, m = divmod(m, 100)
     return datetime(Y % 10000, m, d, H, M, S, tzinfo=timezone.utc)

--- a/tests/test_headerdict.py
+++ b/tests/test_headerdict.py
@@ -7,8 +7,8 @@ def test_init_empty() -> None:
 
 
 def test_init_with_dict() -> None:
-    header_dict = HeaderDict({"key1": "value1"})
-    assert header_dict == {"key1": "value1"}
+    header_dict = HeaderDict({"Key1": "value1"})
+    assert header_dict == {"Key1": "value1"}
 
 
 def test_init_with_list() -> None:
@@ -55,8 +55,9 @@ def test_len() -> None:
 
 def test_eq() -> None:
     header_dict = HeaderDict()
-    header_dict["key"] = "value"
-    assert header_dict == {"key": "value"}
+    header_dict["keylower"] = "value"
+    header_dict["KeYMiXeD"] = "value1"
+    assert header_dict == {"keyLoWer": "value", "keymixed": "value1"}
 
 
 def test_repr() -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,125 @@
+from datetime import datetime, timezone
+from io import StringIO
+
+import pytest
+
+from nntp.utils import (
+    parse_date,
+    parse_epoch,
+    parse_headers,
+    parse_newsgroup,
+    unparse_msgid_range,
+    unparse_range,
+)
+
+
+@pytest.mark.parametrize(
+    ("range", "expected"),
+    [
+        ((1, 10), "1-10"),
+        ((100,), "100-"),
+        pytest.param(None, None, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param((), None, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param((1, 10, 20), None, marks=pytest.mark.xfail(raises=ValueError)),
+    ],
+)
+def test_unparse_range(range, expected):
+    assert unparse_range(range) == expected
+
+
+@pytest.mark.parametrize(
+    ("msgid_range", "expected"),
+    [
+        ("msgid1", "msgid1"),
+        ((1, 10), "1-10"),
+        ((100,), "100-"),
+        pytest.param(None, None, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param((), None, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param((1, 10, 20), None, marks=pytest.mark.xfail(raises=ValueError)),
+    ],
+)
+def test_unparse_msgid_range(msgid_range, expected):
+    assert unparse_msgid_range(msgid_range) == expected
+
+
+@pytest.mark.parametrize(
+    ("line", "expected"),
+    [
+        ("local.test 0 1 y", ("local.test", 0, 1, "y")),
+        ("local.test 0 1 n", ("local.test", 0, 1, "n")),
+        ("alt.test 10 20 y", ("alt.test", 10, 20, "y")),
+        ("alt.test\t10\t20 ?", ("alt.test", 10, 20, "?")),
+        pytest.param("alt.test", None, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param("alt.test 10", None, marks=pytest.mark.xfail(raises=ValueError)),
+        pytest.param(
+            "alt.test 10 20", None, marks=pytest.mark.xfail(raises=ValueError)
+        ),
+    ],
+)
+def test_parse_newsgroup(line, expected):
+    assert parse_newsgroup(line) == expected
+
+
+def test_parse_headers():
+    headers = [
+        "Subject: Test Subject",
+        "From: John Doe <johndoe@example.com>",
+        "Date: Mon, 01 Jan 2022 12:00:00 GMT",
+        "Message-ID: <1234567890@example.com>",
+    ]
+    expected = {
+        "Subject": "Test Subject",
+        "FroM": "John Doe <johndoe@example.com>",
+        "DATE": "Mon, 01 Jan 2022 12:00:00 GMT",
+        "message-id": "<1234567890@example.com>",
+    }
+    assert parse_headers(headers) == expected
+    assert parse_headers("\r\n".join(headers)) == expected
+    assert parse_headers(StringIO("\r\n".join(headers))) == expected
+
+
+def test_parse_headers_continuation():
+    headers = [
+        "Subject: Test Subject",
+        " with continuation",
+        "X-Items: Apple",
+        "\tBanana",
+        "\tCarrot",
+    ]
+    expected = {
+        "Subject": "Test Subject with continuation",
+        "X-Items": "Apple\tBanana\tCarrot",
+    }
+    assert parse_headers(headers) == expected
+
+
+def test_parse_headers_invalid():
+    with pytest.raises(ValueError, match="First header is a continuation"):
+        parse_headers(" Subject: Test Subject")
+    with pytest.raises(ValueError, match="First header is a continuation"):
+        parse_headers("\twith continuation")
+    with pytest.raises(ValueError, match="not enough values to unpack"):
+        parse_headers("Invalid header")
+
+
+@pytest.mark.parametrize(
+    ("date", "expected"),
+    [
+        ("20220101144001", datetime(2022, 1, 1, 14, 40, 1, tzinfo=timezone.utc)),
+        (20220101144001, datetime(2022, 1, 1, 14, 40, 1, tzinfo=timezone.utc)),
+        pytest.param("2022", None, marks=pytest.mark.xfail(raises=ValueError)),
+    ],
+)
+def test_parse_date(date, expected):
+    assert parse_date(date) == expected
+
+
+@pytest.mark.parametrize(
+    ("epoch", "expected"),
+    [
+        ("1641048001", datetime(2022, 1, 1, 14, 40, 1, tzinfo=timezone.utc)),
+        (1641048001, datetime(2022, 1, 1, 14, 40, 1, tzinfo=timezone.utc)),
+    ],
+)
+def test_parse_epoch(epoch, expected):
+    assert parse_epoch(epoch) == expected

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,8 +1,10 @@
 from datetime import datetime, timezone
 from io import StringIO
+from typing import Union
 
 import pytest
 
+from nntp.types import Newsgroup, Range
 from nntp.utils import (
     parse_date,
     parse_epoch,
@@ -23,7 +25,7 @@ from nntp.utils import (
         pytest.param((1, 10, 20), None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_unparse_range(range, expected):
+def test_unparse_range(range: Range, expected: str) -> None:
     assert unparse_range(range) == expected
 
 
@@ -38,7 +40,7 @@ def test_unparse_range(range, expected):
         pytest.param((1, 10, 20), None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_unparse_msgid_range(msgid_range, expected):
+def test_unparse_msgid_range(msgid_range: Union[str, Range], expected: str) -> None:
     assert unparse_msgid_range(msgid_range) == expected
 
 
@@ -56,11 +58,11 @@ def test_unparse_msgid_range(msgid_range, expected):
         ),
     ],
 )
-def test_parse_newsgroup(line, expected):
+def test_parse_newsgroup(line: str, expected: Newsgroup) -> None:
     assert parse_newsgroup(line) == expected
 
 
-def test_parse_headers():
+def test_parse_headers() -> None:
     headers = [
         "Subject: Test Subject",
         "From: John Doe <johndoe@example.com>",
@@ -78,7 +80,7 @@ def test_parse_headers():
     assert parse_headers(StringIO("\r\n".join(headers))) == expected
 
 
-def test_parse_headers_continuation():
+def test_parse_headers_continuation() -> None:
     headers = [
         "Subject: Test Subject",
         " with continuation",
@@ -93,7 +95,7 @@ def test_parse_headers_continuation():
     assert parse_headers(headers) == expected
 
 
-def test_parse_headers_invalid():
+def test_parse_headers_invalid() -> None:
     with pytest.raises(ValueError, match="First header is a continuation"):
         parse_headers(" Subject: Test Subject")
     with pytest.raises(ValueError, match="First header is a continuation"):
@@ -110,7 +112,7 @@ def test_parse_headers_invalid():
         pytest.param("2022", None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_parse_date(date, expected):
+def test_parse_date(date: Union[str, int], expected: datetime) -> None:
     assert parse_date(date) == expected
 
 
@@ -121,5 +123,5 @@ def test_parse_date(date, expected):
         (1641048001, datetime(2022, 1, 1, 14, 40, 1, tzinfo=timezone.utc)),
     ],
 )
-def test_parse_epoch(epoch, expected):
+def test_parse_epoch(epoch: Union[str, int], expected: datetime) -> None:
     assert parse_epoch(epoch) == expected


### PR DESCRIPTION
Bugs squashed:
  * Typo in `parse_date` that broke parsing
  * Fix in `_parse_header` that dropped whitespace from continuation
  * Fixed `HeaderDict.__eq__` to be case insensitive
  * Fix typing for `parse_date` and `parse_epoch`
  * More robust constructor for `HeaderDict`