### PR TITLE
Fix future annotations

### DIFF
--- a/nntp/fifo.py
+++ b/nntp/fifo.py
@@ -16,7 +16,9 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from typing import TYPE_CHECKING, Generic, TypeVar, Union
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Generic, TypeVar
 
 if TYPE_CHECKING:
     from typing_extensions import Self
@@ -34,7 +36,7 @@ class Fifo(Generic[T]):
     empty: T
     eol: T
 
-    def __init__(self, data: Union[T, None] = None) -> None:
+    def __init__(self, data: T | None = None) -> None:
         self.buf: T = data or self.empty
         self.buflist: list[T] = []
         self.pos = 0
@@ -42,7 +44,7 @@ class Fifo(Generic[T]):
     def __len__(self) -> int:
         return len(self.buf) - self.pos
 
-    def __iter__(self) -> "Self":
+    def __iter__(self) -> Self:
         return self
 
     def __next__(self) -> T:

--- a/nntp/headerdict.py
+++ b/nntp/headerdict.py
@@ -16,10 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 from collections import OrderedDict
 from collections.abc import Iterable, Iterator, Mapping, MutableMapping
 from itertools import chain
-from typing import Any, Union
+from typing import Any
 
 __all__ = ["HeaderDict"]
 
@@ -35,7 +37,7 @@ class HeaderName(str):  # noqa: SLOT000
 class HeaderDict(MutableMapping[str, str]):
     def __init__(
         self,
-        other: Union[Mapping[str, str], Iterable[tuple[str, str]], None] = None,
+        other: Mapping[str, str] | Iterable[tuple[str, str]] | None = None,
         **kwargs: str,
     ) -> None:
         self.__proxy = OrderedDict[HeaderName, str]()

--- a/nntp/nntp.py
+++ b/nntp/nntp.py
@@ -16,24 +16,28 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 import io
 import socket
 import ssl
 import zlib
-from collections.abc import Iterable, Iterator, Mapping
 from datetime import datetime, timezone
 from functools import cached_property
-from types import TracebackType
-from typing import TYPE_CHECKING, Any, Literal, Union, overload
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 from . import utils
 from .fifo import BytesFifo
 from .headerdict import HeaderDict
-from .types import Newsgroup, Range
 from .yenc import YEnc, trailer_crc32
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable, Iterator, Mapping
+    from types import TracebackType
+
     from typing_extensions import Self
+
+    from .types import Newsgroup, Range
 
 __all__ = [
     "BaseNNTPClient",
@@ -443,7 +447,7 @@ class BaseNNTPClient:
         for line in self._info(code, message, yz):
             yield line.decode(self.encoding, self.errors)
 
-    def command(self, verb: str, args: Union[str, None] = None) -> tuple[int, str]:
+    def command(self, verb: str, args: str | None = None) -> tuple[int, str]:
         """Call a command on the server.
 
         If the user has not authenticated then authentication will be done
@@ -557,15 +561,15 @@ class NNTPClient(BaseNNTPClient):
         if reader:
             self.mode_reader()
 
-    def __enter__(self) -> "Self":
+    def __enter__(self) -> Self:
         """Support for the 'with' context manager statement."""
         return self
 
     def __exit__(
         self,
-        exc_type: Union[type[BaseException], None],
-        exc_val: Union[BaseException, None],
-        exc_tb: Union[TracebackType, None],
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
     ) -> Literal[False]:
         """Support for the 'with' context manager statement."""
         try:
@@ -576,7 +580,7 @@ class NNTPClient(BaseNNTPClient):
         return False
 
     # session administration commands
-    def capabilities(self, keyword: Union[str, None] = None) -> Iterator[str]:
+    def capabilities(self, keyword: str | None = None) -> Iterator[str]:
         """CAPABILITIES command.
 
         Determines the capabilities of the server.
@@ -746,7 +750,7 @@ class NNTPClient(BaseNNTPClient):
             yield line.strip()
 
     # list commands
-    def list_active(self, pattern: Union[str, None] = None) -> Iterator[Newsgroup]:
+    def list_active(self, pattern: str | None = None) -> Iterator[Newsgroup]:
         """LIST ACTIVE command.
 
         Retrieves a list of active newsgroups that match the specified pattern.
@@ -828,7 +832,7 @@ class NNTPClient(BaseNNTPClient):
 
     def list_newsgroups(
         self,
-        pattern: Union[str, None] = None,
+        pattern: str | None = None,
     ) -> Iterator[tuple[str, str]]:
         """LIST NEWSGROUPS command.
 
@@ -907,7 +911,7 @@ class NNTPClient(BaseNNTPClient):
     def list(
         self,
         keyword: Literal["ACTIVE", None] = None,
-        arg: Union[str, None] = None,
+        arg: str | None = None,
     ) -> Iterator[Newsgroup]: ...
 
     @overload
@@ -927,7 +931,7 @@ class NNTPClient(BaseNNTPClient):
     def list(
         self,
         keyword: Literal["NEWSGROUPS"],
-        arg: Union[str, None] = None,
+        arg: str | None = None,
     ) -> Iterator[tuple[str, str]]: ...
 
     @overload
@@ -944,8 +948,8 @@ class NNTPClient(BaseNNTPClient):
 
     def list(
         self,
-        keyword: Union[str, None] = None,
-        arg: Union[str, None] = None,
+        keyword: str | None = None,
+        arg: str | None = None,
     ) -> Any:
         """LIST command.
 
@@ -1075,7 +1079,7 @@ class NNTPClient(BaseNNTPClient):
         return article, msgid
 
     # TODO: Validate yEnc
-    def _body(self, code: int, message: str, decode: Union[bool, None] = None) -> bytes:
+    def _body(self, code: int, message: str, decode: bool | None = None) -> bytes:
         decoder = YEnc()
 
         # read the body
@@ -1101,8 +1105,8 @@ class NNTPClient(BaseNNTPClient):
 
     def article(
         self,
-        msgid_article: Union[str, int, None] = None,
-        decode: Union[bool, None] = None,
+        msgid_article: str | int | None = None,
+        decode: bool | None = None,
     ) -> tuple[int, HeaderDict, bytes]:
         """ARTICLE command.
 
@@ -1153,7 +1157,7 @@ class NNTPClient(BaseNNTPClient):
 
         return articleno, headers, body
 
-    def head(self, msgid_article: Union[str, int, None] = None) -> HeaderDict:
+    def head(self, msgid_article: str | int | None = None) -> HeaderDict:
         """HEAD command.
 
         Identical to the ARTICLE command except that only the headers are
@@ -1184,8 +1188,8 @@ class NNTPClient(BaseNNTPClient):
 
     def body(
         self,
-        msgid_article: Union[str, int, None] = None,
-        decode: Union[bool, None] = None,
+        msgid_article: str | int | None = None,
+        decode: bool | None = None,
     ) -> bytes:
         """BODY command.
 
@@ -1220,7 +1224,7 @@ class NNTPClient(BaseNNTPClient):
     def _hdr(
         self,
         header: str,
-        msgid_range: Union[str, Range, None] = None,
+        msgid_range: str | Range | None = None,
         verb: str = "HDR",
     ) -> Iterator[tuple[int, str]]:
         args = header
@@ -1244,7 +1248,7 @@ class NNTPClient(BaseNNTPClient):
     def hdr(
         self,
         header: str,
-        msgid_range: Union[str, Range, None] = None,
+        msgid_range: str | Range | None = None,
     ) -> Iterator[tuple[int, str]]:
         """HDR command.
 
@@ -1275,7 +1279,7 @@ class NNTPClient(BaseNNTPClient):
     def xhdr(
         self,
         header: str,
-        msgid_range: Union[str, Range, None] = None,
+        msgid_range: str | Range | None = None,
     ) -> Iterator[tuple[int, str]]:
         """Generator for the XHDR command.
 
@@ -1286,7 +1290,7 @@ class NNTPClient(BaseNNTPClient):
     def xzhdr(
         self,
         header: str,
-        msgid_range: Union[str, Range, None] = None,
+        msgid_range: str | Range | None = None,
     ) -> Iterator[tuple[int, str]]:
         """Generator for the XZHDR command.
 
@@ -1311,7 +1315,7 @@ class NNTPClient(BaseNNTPClient):
 
     def _xover(
         self,
-        range: Union[Range, None] = None,
+        range: Range | None = None,
         verb: str = "XOVER",
     ) -> Iterator[tuple[int, HeaderDict]]:
         # get overview fmt before entering generator
@@ -1337,7 +1341,7 @@ class NNTPClient(BaseNNTPClient):
 
     def xover(
         self,
-        range: Union[Range, None] = None,
+        range: Range | None = None,
     ) -> Iterator[tuple[int, HeaderDict]]:
         """XOVER command.
 
@@ -1368,7 +1372,7 @@ class NNTPClient(BaseNNTPClient):
 
     def xzver(
         self,
-        range: Union[Range, None] = None,
+        range: Range | None = None,
     ) -> Iterator[tuple[int, HeaderDict]]:
         """XZVER command.
 
@@ -1379,7 +1383,7 @@ class NNTPClient(BaseNNTPClient):
     def xpat(
         self,
         header: str,
-        msgid_range: Union[str, Range],
+        msgid_range: str | Range,
         *pattern: str,
     ) -> Iterator[str]:
         """XPAT command.
@@ -1426,9 +1430,9 @@ class NNTPClient(BaseNNTPClient):
 
     def post(
         self,
-        headers: Union[Mapping[str, str], None] = None,
-        body: Union[str, bytes, Iterable[bytes]] = b"",
-    ) -> Union[str, bool]:
+        headers: Mapping[str, str] | None = None,
+        body: str | bytes | Iterable[bytes] = b"",
+    ) -> str | bool:
         """POST command.
 
         Args:

--- a/nntp/utils.py
+++ b/nntp/utils.py
@@ -16,13 +16,17 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from collections.abc import Iterable, Mapping
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from io import StringIO
-from typing import Union
+from typing import TYPE_CHECKING
 
 from .headerdict import HeaderDict
 from .types import Newsgroup, Range
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
 
 
 def unparse_range(obj: Range) -> str:
@@ -56,7 +60,7 @@ def unparse_range(obj: Range) -> str:
     raise ValueError("Must be an integer or tuple")
 
 
-def unparse_msgid_range(obj: Union[str, Range]) -> str:
+def unparse_msgid_range(obj: str | Range) -> str:
     """Unparse a message-id or range argument.
 
     Args:
@@ -106,7 +110,7 @@ def parse_newsgroup(line: str) -> Newsgroup:
     return Newsgroup(name, low, high, status)
 
 
-def _parse_header(line: str) -> Union[str, tuple[str, str], None]:
+def _parse_header(line: str) -> str | tuple[str, str] | None:
     """Parse a header line.
 
     Args:
@@ -130,7 +134,7 @@ def _parse_header(line: str) -> Union[str, tuple[str, str], None]:
     return name.strip(), value.strip()
 
 
-def parse_headers(obj: Union[str, Iterable[str]]) -> HeaderDict:
+def parse_headers(obj: str | Iterable[str]) -> HeaderDict:
     """Parse a string a iterable object (including file like objects) to a
     python dictionary.
 
@@ -186,7 +190,7 @@ def unparse_headers(hdrs: Mapping[str, str]) -> str:
     return "".join([_unparse_header(n, v) for n, v in hdrs.items()]) + "\r\n"
 
 
-def parse_date(value: Union[str, int]) -> datetime:
+def parse_date(value: str | int) -> datetime:
     """Parse a date as returned by the `DATE` command.
 
     Args:
@@ -207,7 +211,7 @@ def parse_date(value: Union[str, int]) -> datetime:
     return datetime(Y % 10000, m, d, H, M, S, tzinfo=timezone.utc)
 
 
-def parse_epoch(value: Union[str, int]) -> datetime:
+def parse_epoch(value: str | int) -> datetime:
     """Parse a date as returned by the `DATE` command.
 
     Args:

--- a/nntp/yenc.py
+++ b/nntp/yenc.py
@@ -16,11 +16,12 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from __future__ import annotations
+
 import binascii
 import re
 import struct
 import zlib
-from typing import Union
 
 __all__ = ["trailer_crc32", "YEnc"]
 
@@ -28,7 +29,7 @@ __all__ = ["trailer_crc32", "YEnc"]
 _crc32_re = re.compile(b"\\s+crc(?:32)?=([0-9a-fA-F]{8})")
 
 
-def trailer_crc32(trailer: bytes) -> Union[int, None]:
+def trailer_crc32(trailer: bytes) -> int | None:
     """Extract the CRC32 value from a yEnc trailer."""
     match = _crc32_re.search(trailer)
     if not match:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,10 +1,11 @@
+from __future__ import annotations
+
 from datetime import datetime, timezone
 from io import StringIO
-from typing import Union
+from typing import TYPE_CHECKING
 
 import pytest
 
-from nntp.types import Newsgroup, Range
 from nntp.utils import (
     parse_date,
     parse_epoch,
@@ -13,6 +14,9 @@ from nntp.utils import (
     unparse_msgid_range,
     unparse_range,
 )
+
+if TYPE_CHECKING:
+    from nntp.types import Newsgroup, Range
 
 
 @pytest.mark.parametrize(
@@ -40,7 +44,7 @@ def test_unparse_range(range: Range, expected: str) -> None:
         pytest.param((1, 10, 20), None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_unparse_msgid_range(msgid_range: Union[str, Range], expected: str) -> None:
+def test_unparse_msgid_range(msgid_range: str | Range, expected: str) -> None:
     assert unparse_msgid_range(msgid_range) == expected
 
 
@@ -112,7 +116,7 @@ def test_parse_headers_invalid() -> None:
         pytest.param("2022", None, marks=pytest.mark.xfail(raises=ValueError)),
     ],
 )
-def test_parse_date(date: Union[str, int], expected: datetime) -> None:
+def test_parse_date(date: str | int, expected: datetime) -> None:
     assert parse_date(date) == expected
 
 
@@ -123,5 +127,5 @@ def test_parse_date(date: Union[str, int], expected: datetime) -> None:
         (1641048001, datetime(2022, 1, 1, 14, 40, 1, tzinfo=timezone.utc)),
     ],
 )
-def test_parse_epoch(epoch: Union[str, int], expected: datetime) -> None:
+def test_parse_epoch(epoch: str | int, expected: datetime) -> None:
     assert parse_epoch(epoch) == expected


### PR DESCRIPTION
Add `from __future__ import annotations` to enable modern type syntax.
https://docs.python.org/3/library/__future__.html