### PR TITLE
Add support for STARTTLS based SSL

### DIFF
--- a/nntp/types.py
+++ b/nntp/types.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import NamedTuple, Union
 
 Range = Union[int, tuple[int], tuple[int, int]]
@@ -8,3 +9,16 @@ class Newsgroup(NamedTuple):
     low: int
     high: int
     status: str
+
+
+class SSLMode(str, Enum):
+    IMPLICIT = "implicit"
+    """Establish secure connection immediately.
+    You need to use a different port (usually 563) in this mode.
+    """
+
+    STARTTLS = "starttls"
+    """Establish secure connection dynamically after sending a `STARTTLS` command.
+    This mode is not recommended. See <https://www.rfc-editor.org/rfc/rfc8143.html#section-2>
+    You can use the same port (usually 119) this mode.
+    """


### PR DESCRIPTION
Update tests now that the `greenbender/inn:0.9.1` docker image supports TLS.

Enable disabling cert validation using and env var to make testing easier.