### PR TITLE
Let's make dependabot and pre-commit less chatty

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,4 +22,4 @@ updates:
           - patch
           - minor
     schedule:
-      interval: weekly
+      interval: monthly

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,6 @@
+ci:
+  autoupdate_schedule: monthly
+
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0


### PR DESCRIPTION
```diff
    schedule:
-     interval: weekly
+     interval: monthly
```
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#interval
```diff
ci:
- autoupdate_schedule: weekly
+ autoupdate_schedule: monthly
```
https://pre-commit.ci/#configuration